### PR TITLE
Add Signal website source for APKs without Google Play Services.

### DIFF
--- a/app/src/main/assets/sources.json
+++ b/app/src/main/assets/sources.json
@@ -147,5 +147,16 @@
         "download_regexp": "(?:Experimental|Stable) <i>.*?a href=\"(.*?\.apk)"
       }
     }
+  },
+  {
+    "name": "Signal",
+    "url": "https://updates.signal.org/android/latest.json",
+    "packages": {
+      "^org.thoughtcrime.securesms$": {
+        "version": "\"versionName\" : \"(.*?)\"",
+        "download_regexp": "\"url\" : \"(.*?\.apk)\""
+      }
+    },
+    "autoselect_if": ["metadata=org.thoughtcrime.securesms.service.UpdateApkRefreshListener"]
   }
 ]


### PR DESCRIPTION
Adds the APK from https://signal.org/android/apk/ as a source, autoselecting it if the app manifest includes `org.thoughtcrime.securesms.service.UpdateApkRefreshListener` (which the Google Play Services version doesn't register as a receiver because they rely on the Play Store for update notifications and such).

(I actually use the Play Store myself mostly, but a paranoid friend asked me earlier today how best to keep track of updates for the apps they'd sideloaded onto their phone and I went, ooh, there's that nifty ApkTrack app that'd probably work for ya! And thus started my journey down the rabbit hole that has ended for now in this pull request ;))