### PR TITLE
Updated English and German strings WRT liability and consistency of their wording, mostly unifying the use of "apps" / "applications" to "apps" only

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -77,7 +77,7 @@
     <string name="clean_downloads">Von ApkTrack heruntergeladene APKs löschen</string>
     <string name="clean_downloads_description">Momentan sind %1$d APK(s) auf dem Gerät gespeichert.</string>
     <string name="refresh_installed_apps">App-Liste neu laden</string>
-    <string name="refresh_installed_apps_desc">Neuerkennung installierter Apps und ihrer Versionsnummern.</string>
+    <string name="refresh_installed_apps_desc">Neuerkennung installierter Apps und ihrer Versionen.</string>
     <string name="refresh_installed_apps_desc_2">Gerät wird durchsucht...</string>
     <string name="refresh_installed_apps_desc_3">%1$d aktualisierte, %2$d neue und %3$d gelöschte Apps gefunden.</string>
     <!-- Context: appears in a list with "SOCKS" and "HTTP". -->

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -14,7 +14,7 @@
   ~
   ~ You should have received a copy of the GNU General Public License
   ~ along with ApkTrack.  If not, see <http://www.gnu.org/licenses/>.
-  -->
+    -->
 <resources xmlns:tools="http://schemas.android.com/tools" tools:locale="en">
     <string name="app_name">ApkTrack</string>
     <!-- Menu bar strings -->
@@ -99,7 +99,7 @@
     <string name="pref_acra_disabled">Beim Auftreten von Fehlern werden keine Absturzberichte gesendet.</string>
     <string name="crash_dialog_title">ApkTrack ist abgestürzt</string>
     <string name="crash_dialog_text">Ein unerwarteter Fehler ist aufgetreten und die Applikation abgestürzt. Hilf mit den Fehler zu beseitigen und sende einen Absturzbericht. 
-Einfach auf OK klicken.</string>
+    Einfach auf OK klicken.</string>
     <string name="crash_dialog_comment_prompt">Ein Kommentar kann unten hinzugefügt werden:</string>
     <string name="crash_dialog_ok_toast">Vielen Dank!</string>
     <string name="crash_user_email_label">Gib deine E-Mail Adresse an, um zu diesem Fehler kontaktiert zu werden (optional):</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -74,11 +74,11 @@
     <string name="proxy_type">Proxy-Typ</string>
     <string name="proxy_address">Proxy-Adresse</string>
     <string name="no_proxy">Kein</string>
-    <string name="clean_downloads">Heruntergeladene APKs löschen</string>
+    <string name="clean_downloads">Von ApkTrack heruntergeladene APKs löschen</string>
     <string name="clean_downloads_description">Momentan sind %1$d APK(s) auf dem Gerät gespeichert.</string>
     <string name="refresh_installed_apps">App-Liste neu laden</string>
     <string name="refresh_installed_apps_desc">Neuerkennung installierter Apps und ihrer Versionsnummern.</string>
-    <string name="refresh_installed_apps_desc_2">Gerät wird durchsucht ...</string>
+    <string name="refresh_installed_apps_desc_2">Gerät wird durchsucht...</string>
     <string name="refresh_installed_apps_desc_3">%1$d aktualisierte, %2$d neue und %3$d gelöschte Apps gefunden.</string>
     <!-- Context: appears in a list with "SOCKS" and "HTTP". -->
     <string name="no_proxy_summary">%s (ApkTrack greift direkt auf das Internet zu).</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -83,8 +83,8 @@
     <!-- Context: appears in a list with "SOCKS" and "HTTP". -->
     <string name="no_proxy_summary">%s (ApkTrack greift direkt auf das Internet zu).</string>
     <string name="invalid_proxy_address">Die angegebene Adresse ist ungültig.</string>
-    <string name="http_proxy_summary">ApkTrack greift durch einen HTTP-Proxy auf das Internet zu.</string>
-    <string name="socks_proxy_summary">ApkTrack greift durch einen SOCKS-Proxy auf das Internet zu.</string>
+    <string name="http_proxy_summary">ApkTrack greift über einen HTTP-Proxy auf das Internet zu.</string>
+    <string name="socks_proxy_summary">ApkTrack greift über einen SOCKS-Proxy auf das Internet zu.</string>
     <string name="proxy_warning_title">Warnung</string>
     <string name="proxy_warning_text">Zur Zeit werden die Proxy-Einstellungen lediglich für Aktualisierungs-Überprüfungen verwendet.\nFür das Herunterladen von APKs wird der systemweite Download-Manager oder ein Web-Browser verwendet, für die ggf. ein anderer oder kein Proxy eingestellt ist.</string>
     <!-- Error messages -->
@@ -98,7 +98,7 @@
     <string name="pref_acra_enabled">Beim Auftreten von Fehlern werden Absturzberichte an den Programmierer von ApkTrack gesendet.</string>
     <string name="pref_acra_disabled">Beim Auftreten von Fehlern werden keine Absturzberichte gesendet.</string>
     <string name="crash_dialog_title">ApkTrack ist abgestürzt</string>
-    <string name="crash_dialog_text">Ein unerwarteter Fehler ist aufgetreten und die Applikation abgestürzt. Hilf mit den Fehler zu beseitigen und sende einen Absturzbericht. 
+    <string name="crash_dialog_text">Ein unerwarteter Fehler ist aufgetreten und die Applikation abgestürzt./nHilf mit den Fehler zu beseitigen und sende einen Absturzbericht. 
     Einfach auf OK klicken.</string>
     <string name="crash_dialog_comment_prompt">Ein Kommentar kann unten hinzugefügt werden:</string>
     <string name="crash_dialog_ok_toast">Vielen Dank!</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -24,7 +24,7 @@
     <string name="sort_type_alpha">Sortiere alphabetisch</string>
     <string name="sort_type_updated">Sortiere nach Status</string>
     <string name="settings">Einstellungen</string>
-    <string name="search">Suche Apps</string>
+    <string name="search">Durchsuche App-Liste</string>
     <!-- Notification strings -->
     <string name="app_updated_notification">%1$s aktualisiert.</string>
     <string name="apps_updated_notification">Neue Aktualisierungen gefunden.</string>
@@ -51,46 +51,46 @@
     <string name="preferred_search_engine">Bevorzugte Suchmaschine</string>
     <string name="preferred_search_engine_desc">Wähle aus, welche Suchmaschine zum Suchen von APKs benutzt werden soll.\nAktuelle Auswahl: %s</string>
     <string name="enable_background_checks">Aktiviere Hintergrund-Überprüfung</string>
-    <string name="enable_background_checks_desc_enabled">Aktualisierungsüberprüfungen erfolgen täglich.</string>
-    <string name="enable_background_checks_desc_disabled">Aktualisierungsüberprüfungen erfolgen nur nach manueller Abfrage.</string>
+    <string name="enable_background_checks_desc_enabled">Aktualisierungs-Überprüfungen erfolgen täglich.</string>
+    <string name="enable_background_checks_desc_disabled">Aktualisierungs-Überprüfungen erfolgen ausschließlich manuell ausgelöst.</string>
     <string name="background_checks_on_wifi_only">Nur W-LAN</string>
-    <string name="background_checks_on_wifi_only_desc_enabled">Für Hintergrund-Überpüfungen werden niemals mobile Daten verwendet.</string>
+    <string name="background_checks_on_wifi_only_desc_enabled">Für Hintergrund-Überprüfungen werden niemals mobile Daten verwendet.</string>
     <string name="background_checks_on_wifi_only_desc_disabled">Für Hintergrund-Überprüfungen können mobile Daten verwendet werden.</string>
     <string name="enable_automatic_downloads">Lade Aktualisierungen automatisch herunter</string>
     <string name="enable_automatic_downloads_desc_enabled">Aktualisierungen werden automatisch heruntergeladen, sobald sie verfügbar sind.</string>
-    <string name="enable_automatic_downloads_desc_disabled">Das Herunterladen der APKs muss manuell ausgelöst werden.</string>
-    <string name="appearance">Aussehen</string>
+    <string name="enable_automatic_downloads_desc_disabled">Das Herunterladen von APKs muss manuell ausgelöst werden.</string>
+    <string name="appearance">Darstellung</string>
     <string name="hide_unknown_apps">Verstecke unbekannte Apps</string>
-    <string name="hide_unknown_apps_desc">Zeige Apps, die keine Updateinformationen erhalten nicht an</string>
+    <string name="hide_unknown_apps_desc">Zeige Apps nicht an, für die keine Aktualisierungs-Informationen gefunden wurden.</string>
     <string name="ignored_settings">Ignorierte Apps</string>
-    <string name="ignore_xposed_apps">Ignoriere Xposed Apps</string>
-    <string name="ignore_xposed_apps_desc">Klicken, um Aktualisierungsüberprüfung für Xposed Apps zu deaktivieren.</string>
-    <string name="ignore_system_apps">Ignoriere System Apps</string>
-    <string name="ignore_system_apps_desc">Klicken, um Aktualisierungsüberprüfung für System Apps zu deaktivieren</string>
+    <string name="ignore_xposed_apps">Ignoriere Xposed-Apps</string>
+    <string name="ignore_xposed_apps_desc">Klicken, um Aktualisierungs-Überprüfungen für Xposed-Apps zu deaktivieren.</string>
+    <string name="ignore_system_apps">Ignoriere System-Apps</string>
+    <string name="ignore_system_apps_desc">Klicken, um Aktualisierungs-Überprüfungen für System-Apps zu deaktivieren.</string>
     <string name="ignore_unknown_apps">Unbekannte Apps ignorieren</string>
-    <string name="ignore_unknown_apps_desc">Klicken, um Überprüfung von Apps zu deaktivieren, deren Aktualisierungsquelle nicht gefunden werden konnte.</string>
-    <string name="reset_ignored_apps">Ignorierte Apps zurücksetzen</string>
-    <string name="click_to_unignore">Klicken, um Ignorieren aller Apps rückgängig zu machen.</string>
-    <string name="proxy_type">Proxy Typ</string>
-    <string name="proxy_address">Proxy Adresse</string>
+    <string name="ignore_unknown_apps_desc">Klicken, um Überprüfungen von Apps zu deaktivieren, deren Aktualisierungs-Quelle nicht gefunden werden konnte.</string>
+    <string name="reset_ignored_apps">Auswahl ignorierter Apps zurücksetzen</string>
+    <string name="click_to_unignore">Klicken, um die Auswahl ignorierter Apps zurückzusetzen.</string>
+    <string name="proxy_type">Proxy-Typ</string>
+    <string name="proxy_address">Proxy-Adresse</string>
     <string name="no_proxy">Kein</string>
-    <string name="clean_downloads">Herundergeladene APKs löschen</string>
-    <string name="clean_downloads_description">Aktuell sind %1$d APK(s) auf dem Gerät gespeichert.</string>
+    <string name="clean_downloads">Heruntergeladene APKs löschen</string>
+    <string name="clean_downloads_description">Momentan sind %1$d APK(s) auf dem Gerät gespeichert.</string>
     <string name="refresh_installed_apps">App-Liste neu laden</string>
-    <string name="refresh_installed_apps_desc">Neuerkennung installierter Apps und Versionen.</string>
-    <string name="refresh_installed_apps_desc_2">Gerät durchsuchen...</string>
+    <string name="refresh_installed_apps_desc">Neuerkennung installierter Apps und ihrer Versionsnummern.</string>
+    <string name="refresh_installed_apps_desc_2">Gerät wird durchsucht ...</string>
     <string name="refresh_installed_apps_desc_3">%1$d aktualisierte, %2$d neue und %3$d gelöschte Apps gefunden.</string>
     <!-- Context: appears in a list with "SOCKS" and "HTTP". -->
-    <string name="no_proxy_summary">%s (ApkTrak greift direkt auf das Internet zu).</string>
+    <string name="no_proxy_summary">%s (ApkTrack greift direkt auf das Internet zu).</string>
     <string name="invalid_proxy_address">Die angegebene Adresse ist ungültig.</string>
     <string name="http_proxy_summary">ApkTrack greift durch einen HTTP-Proxy auf das Internet zu.</string>
     <string name="socks_proxy_summary">ApkTrack greift durch einen SOCKS-Proxy auf das Internet zu.</string>
     <string name="proxy_warning_title">Warnung</string>
-    <string name="proxy_warning_text">Momentan kann der Proxy nur für Versionsüberprüfungen verwendet werden. APK-Downloads werden durch den systemeigenen  Download Manager geschleust, welcher möglicherweise nicht zur Nutzung des Proxy konfugiert wurde.</string>
+    <string name="proxy_warning_text">Zur Zeit werden die Proxy-Einstellungen lediglich für Aktualisierungs-Überprüfungen verwendet.\nFür das Herunterladen von APKs wird der systemweite Download-Manager oder ein Web-Browser verwendet, für die ggf. ein anderer oder kein Proxy eingestellt ist.</string>
     <!-- Error messages -->
-    <string name="search_no_result">Keine Ergebnisse gefunden</string>
-    <string name="cant_handle_view">Keinen Browser gefunden. Bitte besuche http://apktrack.kwiatkowski.fr/privacy !</string>
-    <!-- Context: The update source resturned a response, but no version number could be found inside it. -->
+    <string name="search_no_result">Keine Ergebnisse gefunden.</string>
+    <string name="cant_handle_view">Keinen Browser gefunden. Bitte besuche http://apktrack.kwiatkowski.fr/privacy</string>
+    <!-- Context: The update source returned a response, but no version number could be found inside it. -->
     <string name="regexp_no_match">Versionsnummer kann nicht ausgelesen werden.</string>
     <!-- Crash report dialog and settings -->
     <string name="crash_reports_pref_category">Absturzberichte</string>
@@ -100,14 +100,14 @@
     <string name="crash_dialog_title">ApkTrack ist abgestürzt</string>
     <string name="crash_dialog_text">Ein unerwarteter Fehler ist aufgetreten und die Applikation abgestürzt. Hilf mit den Fehler zu beseitigen und sende einen Absturzbericht. 
 Einfach auf OK klicken.</string>
-    <string name="crash_dialog_comment_prompt">Kommentare können unten hinzugefügt werden:</string>
+    <string name="crash_dialog_comment_prompt">Ein Kommentar kann unten hinzugefügt werden:</string>
     <string name="crash_dialog_ok_toast">Vielen Dank!</string>
-    <string name="crash_user_email_label">Gib deine E-Mail Adresse an, um zu diesem Fehler kontaktiert zu werden(optional):</string>
+    <string name="crash_user_email_label">Gib deine E-Mail Adresse an, um zu diesem Fehler kontaktiert zu werden (optional):</string>
     <string name="pref_acra_alwaysaccept">Absturzberichte immer senden</string>
     <string name="pref_acra_alwaysaccept_enabled">Absturzberichte werden automatisch gesendet.</string>
     <string name="pref_acra_alwaysaccept_disabled">Es erscheint ein Bestätigungsfenster, bevor Daten gesendet werden.</string>
     <string name="pref_privacy_policy">Datenschutzerklärung</string>
-    <string name="pref_privacy_policy_summary">Lies ApkTracks Datenschutzerklärung. TL;DR: persönliche Daten werden niemals irgendjemandem mitgeteilt.</string>
+    <string name="pref_privacy_policy_summary">Lies ApkTracks Datenschutzerklärung. TL;DR: Persönliche Daten werden niemals irgendjemandem mitgeteilt.</string>
     <string name="enable_background_checks_desc">Führe regelmäßige Hintergrund-Überprüfungen für alle Apps aus.</string>
     <string name="background_checks_on_wifi_only_desc">Nutze niemals mobile Daten für Hintergrund-Überprüfungen.</string>
     <string name="test_proxy">Proxy-Einstellungen testen</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -21,13 +21,13 @@
     <string name="loader_desc" translatable="false">Spinner</string>
     <string name="status_icon_desc" translatable="false">Status icon</string>
     <!-- Menu bar strings -->
-    <string name="check_all_apps_desc">Check updates for all applications</string>
-    <string name="show_system_apps">Show system applications</string>
-    <string name="hide_system_apps">Hide system applications</string>
+    <string name="check_all_apps_desc">Check for updates of all apps</string>
+    <string name="show_system_apps">Show system apps</string>
+    <string name="hide_system_apps">Hide system apps</string>
     <string name="sort_type_alpha">Sort alphabetically</string>
     <string name="sort_type_updated">Sort by status</string>
     <string name="settings">Settings</string>
-    <string name="search">Search apps or packages</string>
+    <string name="search">Search in app list</string>
     <!-- Notification strings -->
     <string name="app_updated_notification">%1$s updated.</string>
     <string name="apps_updated_notification">New updates found.</string>
@@ -47,7 +47,7 @@
     <string name="undo">Undo</string>
     <!-- Dialogs -->
     <string name="available_update_sources">Available update sources</string>
-    <string name="confirm_reset_ignored">Are you sure you want to reset ignored apps?</string>
+    <string name="confirm_reset_ignored">Are you sure you want to reset the current selection of ignored apps?</string>
     <string name="ok">OK</string>
     <string name="cancel">Cancel</string>
     <!-- Settings strings -->
@@ -63,36 +63,36 @@
     <string name="background_checks_on_wifi_only_desc_disabled">Mobile data may be used during background checks.</string>
     <string name="enable_automatic_downloads">Automatically download APKs</string>
     <string name="enable_automatic_downloads_desc_enabled">APKs will be downloaded automatically when they become available.</string>
-    <string name="enable_automatic_downloads_desc_disabled">APKs downloads will have to be triggered manually.</string>
+    <string name="enable_automatic_downloads_desc_disabled">APKs downloads must be triggered manually.</string>
     <string name="appearance">Appearance</string>
     <string name="hide_unknown_apps">Hide unknown applications</string>
-    <string name="hide_unknown_apps_desc">Don\'t show applications for which no update information could be found</string>
+    <string name="hide_unknown_apps_desc">Do not show apps for which no update information could be found.</string>
     <string name="ignored_settings">Ignored apps</string>
     <string name="ignore_xposed_apps">Ignore Xposed apps</string>
     <string name="ignore_xposed_apps_desc">Click to disable update checks for Xposed apps.</string>
     <string name="ignore_system_apps">Ignore system apps</string>
     <string name="ignore_system_apps_desc">Click to disable update checks for system apps.</string>
     <string name="ignore_unknown_apps">Ignore unknown apps</string>
-    <string name="ignore_unknown_apps_desc">Click to disable check for apps whose update source could not be determined.</string>
+    <string name="ignore_unknown_apps_desc">Click to disable checks for apps whose update source could not be determined.</string>
     <string name="reset_ignored_apps">Reset ignored apps</string>
     <string name="click_to_unignore">Click to un-ignore all apps.</string>
     <string name="proxy_type">Proxy type</string>
     <string name="proxy_address">Proxy address</string>
     <string name="no_proxy">None</string>
-    <string name="clean_downloads">Clean downloaded APKs</string>
+    <string name="clean_downloads">Delete APKs downloaded by ApkTrack</string>
     <string name="clean_downloads_description">There are currently %1$d APK(s) stored on your device.</string>
     <string name="refresh_installed_apps">Refresh app list</string>
-    <string name="refresh_installed_apps_desc">Redetect installed applications and their version.</string>
+    <string name="refresh_installed_apps_desc">Redetect installed apps and their versions.</string>
     <string name="refresh_installed_apps_desc_2">Scanning device…</string>
     <string name="refresh_installed_apps_desc_3">Detected %1$d updated, %2$d new and %3$d deleted app(s).</string>
     <!-- Context: appears in a list with "SOCKS" and "HTTP". -->
     <string name="no_proxy_summary">%s (ApkTrack accesses the internet directly).</string>
     <string name="invalid_proxy_address">The address specified is invalid!</string>
-    <string name="http_proxy_summary">ApkTrack accesses the internet through an HTTP proxy.</string>
-    <string name="socks_proxy_summary">ApkTrack accesses the internet through a SOCKS proxy.</string>
+    <string name="http_proxy_summary">ApkTrack accesses the internet via an HTTP proxy.</string>
+    <string name="socks_proxy_summary">ApkTrack accesses the internet via a SOCKS proxy.</string>
     <string name="proxy_warning_title">Warning</string>
-    <string name="proxy_warning_text">At the moment, the proxy can only be used for version checks.\nAPK downloads go
-        through the system\'s download manager or your browser, which may not be configured to use the proxy.</string>
+    <string name="proxy_warning_text">At the moment, the proxy can only be used for update checks.\nAPK downloads are
+    carried out by the system\'s download manager or your browser, which may not be configured to use this proxy.</string>
     <!-- Error messages -->
     <string name="search_no_result">No results found</string>
     <string name="cant_handle_view">No browser found. Please visit http://apktrack.kwiatkowski.fr/privacy manually!</string>
@@ -104,18 +104,17 @@
     <string name="pref_acra_enabled">Crash reports will be sent to ApkTrack\'s maintainer if bugs are encountered.</string>
     <string name="pref_acra_disabled">No crash reports will be sent if bugs are encountered.</string>
     <string name="crash_dialog_title">ApkTrack has crashed</string>
-    <string name="crash_dialog_text">An unexpected error occurred forcing the
-    application to stop. Please help me fix this by sending error data.
-    All you have to do is click OK.</string>
-    <string name="crash_dialog_comment_prompt">You may add comments about the problem below:</string>
+    <string name="crash_dialog_text">An unexpected error occurred forcing the application to stop./n 
+    Please help fixing this by sending error data. Just click OK to send.</string>
+    <string name="crash_dialog_comment_prompt">You may add a comment about this issue below:</string>
     <string name="crash_dialog_ok_toast">Thank you!</string>
-    <string name="crash_user_email_label">Your e-mail address if you wish to be contacted about this error (optional):</string>
+    <string name="crash_user_email_label">Your e-mail address, if you wish to be contacted about this error (optional):</string>
     <string name="pref_acra_alwaysaccept">Always send crash reports</string>
     <string name="pref_acra_alwaysaccept_enabled">Crash reports will be sent automatically.</string>
     <string name="pref_acra_alwaysaccept_disabled">You will be prompted before any data is sent.</string>
     <string name="pref_privacy_policy">Privacy policy</string>
-    <string name="pref_privacy_policy_summary">Read ApkTrack\'s privacy policy. TL;DR: your data will never be shared with anyone.</string>
-    <string name="enable_background_checks_desc">Perform automatic update checks periodically for all applications.</string>
+    <string name="pref_privacy_policy_summary">Read ApkTrack\'s privacy policy. TL;DR: Your data will never be shared with anyone.</string>
+    <string name="enable_background_checks_desc">Perform automatic update checks periodically for all apps.</string>
     <string name="background_checks_on_wifi_only_desc">Never use mobile data to perform background checks.</string>
     <string name="test_proxy">Test proxy settings</string>
     <string name="test_proxy_desc">Initiates a connection to ApkTrack\'s servers to check connectivity.</string>


### PR DESCRIPTION
While I originally intended to create two separate pull requests for the English and German strings, I messed this up in my internal branches, so I had to merge the English language changes into the German ones to avoid manual conflict resolution.
Most of the German language fixes and improvements are due to messing them up in a similar manner two days ago, without noticing this early enough.
A few improvements originate from the fact, that it is quite helpful to jump back and forth between those two languages, as this helps to have a deeper understanding how to express things concisely.